### PR TITLE
Improve Windows support

### DIFF
--- a/Data/Conduit/Algorithms/Async.hs
+++ b/Data/Conduit/Algorithms/Async.hs
@@ -41,10 +41,7 @@ import qualified Data.Conduit.List as CL
 import qualified Data.Conduit.Zlib as CZ
 import qualified Data.Conduit.Lzma as CX
 import qualified Data.Streaming.Zlib as SZ
-#ifndef WINDOWS
--- bzlib cannot compile on Windows (as of 2016/07/05)
 import qualified Data.Conduit.BZlib as CZ
-#endif
 import qualified Data.Conduit as C
 import           Data.Conduit ((.|))
 
@@ -248,11 +245,7 @@ asyncBzip2To h = do
                 CA.sourceTBQueue q
                     .| untilNothing
                     .| CL.map (B.concat . reverse)
-#ifndef WINDOWS
                     .| CZ.bzip2
-#else
-                    .| error "bzip2 compression is not available on Windows"
-#endif
                     .| C.sinkHandle h
     bsConcatTo ((2 :: Int) ^ (15 :: Int))
         .| CA.drainTo 8 drain
@@ -277,11 +270,7 @@ asyncBzip2From h = do
     let prod q = do
                     C.runConduit $
                         C.sourceHandle h
-#ifndef WINDOWS
                             .| CZ.multiple CZ.bunzip2
-#else
-                            .| error "bzip2 decompression is not available on Windows"
-#endif
                             .| CL.map Just
                             .| CA.sinkTBQueue q
                     liftIO $ atomically (TQ.writeTBQueue q Nothing)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+# Disabled cache in hope of improving reliability of AppVeyor builds
+#cache:
+#- "c:\\sr" # stack root, short paths == fewer problems
+
+# Uncomment the following to enable interactive remote desktop during (init) and after (on_finish) building
+# More info at https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
+# init:
+#   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# 
+# on_finish:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+build: off
+
+before_test:
+# http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
+- set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+
+- curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
+- 7z x stack.zip stack.exe
+
+clone_folder: "c:\\stack"
+environment:
+  global:
+    STACK_ROOT: "c:\\sr"
+
+test_script:
+- stack setup > nul
+# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
+# descriptor
+- echo "" | stack --no-terminal test --jobs 1

--- a/package.yaml
+++ b/package.yaml
@@ -32,6 +32,7 @@ dependencies:
   - conduit-extra
   - containers
   - deepseq
+  - monad-control
   - mtl
   - resourcet
   - streaming-commons

--- a/package.yaml
+++ b/package.yaml
@@ -32,7 +32,6 @@ dependencies:
   - conduit-extra
   - containers
   - deepseq
-  - lzma-conduit
   - mtl
   - resourcet
   - streaming-commons
@@ -40,6 +39,14 @@ dependencies:
   - stm-conduit >= 2.7
   - vector
   - transformers
+
+when:
+  - condition: ! 'os(windows)'
+    then:
+     cpp-options: -DWINDOWS
+    else:
+     dependencies:
+     - lzma-conduit
 
 library:
   exposed-modules:

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -14,12 +14,15 @@ import qualified Data.Conduit as C
 import qualified Data.Conduit.Combinators as CC
 import qualified Data.Conduit.Binary as CB
 import qualified Data.Conduit.List as CL
+import qualified Data.Functor.Identity as FID
 import qualified Data.Vector.Storable as VS
 import           Data.Conduit ((.|))
 import           Data.List (sort)
 import           System.Directory (removeFile)
 import           Control.Exception (catch, ErrorCall)
 import           Control.Monad (forM_)
+import           Control.Monad.Trans.Resource.Internal (ResourceT)
+import           Control.Monad.Trans.Control (MonadBaseControl)
 
 import qualified Data.Conduit.Algorithms as CAlg
 import qualified Data.Conduit.Algorithms.Storable as CAlg
@@ -43,11 +46,16 @@ testingFileNameXZ = "file_just_for_testing_delete_me_please.xz"
 testingFileNameXZ2 :: FilePath
 testingFileNameXZ2 = "file_just_for_testing_delete_me_please_2.xz"
 
+extract :: C.ConduitM () b FID.Identity () -> [b]
 extract c = C.runConduitPure (c .| CC.sinkList)
 
+extractIO :: MonadBaseControl IO m => C.ConduitM () b (ResourceT m) () -> m [b]
 extractIO c = C.runConduitRes (c .| CC.sinkList)
 
+shouldProduce :: (Show b, Eq b) => [b] -> C.ConduitM () b FID.Identity () -> Assertion
 shouldProduce values cond = extract cond @?= values
+
+shouldProduceIO :: (Show b, Eq b) => [b] -> C.ConduitM () b (ResourceT IO) () -> IO ()
 shouldProduceIO values cond = do
     p <- extractIO cond
     p @?= values
@@ -63,7 +71,9 @@ assertError f = do
         handler :: ErrorCall -> IO Bool
         handler _ = pure True
 
+case_uniqueC :: Assertion
 case_uniqueC = extract (CC.yieldMany [1,2,3,1,1,2,3] .| CAlg.uniqueC) @=? [1,2,3 :: Int]
+case_mergeC :: Assertion
 case_mergeC = shouldProduce expected $
                             CAlg.mergeC
                                 [ CC.yieldMany i1
@@ -77,6 +87,7 @@ case_mergeC = shouldProduce expected $
         i2 = [ 1, 4, 4, 5]
         i3 = [-1, 0, 7]
 
+case_mergeCmonad :: Assertion
 case_mergeCmonad = shouldProduce expected $
                             CAlg.mergeC
                                 [ mYield i1
@@ -87,26 +98,30 @@ case_mergeCmonad = shouldProduce expected $
         expected = sort (concat [i1, i2, i3])
         mYield lst = do
             let lst' = map return lst
-            forM_ lst' $ \elem -> do
-                elem' <- elem
-                C.yield elem'
+            forM_ lst' $ \elemnt -> do
+                elemnt' <- elemnt
+                C.yield elemnt'
         i1 = [ 0, 2, 4 :: Int]
         i2 = [ 1, 3, 4, 5]
         i3 = [-1, 0, 7]
 
 
+case_mergeCempty :: Assertion
 case_mergeCempty = shouldProduce ([] :: [Int]) $ CAlg.mergeC []
 
+case_mergeC2 :: Assertion
 case_mergeC2 = shouldProduce [0, 1, 1, 2, 3, 5 :: Int] $
                             CAlg.mergeC2
                                 (CC.yieldMany [0, 1, 2])
                                 (CC.yieldMany [1, 3, 5])
 
+case_mergeC2same :: Assertion
 case_mergeC2same = shouldProduce [0, 0, 1, 1, 2, 2 :: Int] $
                             CAlg.mergeC2
                                 (CC.yieldMany [0, 1, 2])
                                 (CC.yieldMany [0, 1, 2])
 
+case_mergeC2monad :: Assertion
 case_mergeC2monad = shouldProduce [0, 1, 2, 2, 3, 4 :: Int] $ do
                             CAlg.mergeC2
                                 (CC.yieldMany [0, 2])
@@ -114,36 +129,39 @@ case_mergeC2monad = shouldProduce [0, 1, 2, 2, 3, 4 :: Int] $ do
                             CC.yieldMany [3]
                             CC.yieldMany [4]
 
+case_groupC :: Assertion
 case_groupC = shouldProduce [[0,1,2], [3,4,5], [6,7,8], [9, 10 :: Int]] $
                             CC.yieldMany [0..10] .| CAlg.groupC 3
 
+case_enumerateC :: Assertion
 case_enumerateC = shouldProduce [(0,'z'), (1,'o'), (2,'t')] $
-                            CC.yieldMany ("zot" :: [Char]) .| CAlg.enumerateC
+                            CC.yieldMany ("zot" :: String) .| CAlg.enumerateC
 
+case_removeRepeatsC :: Assertion
 case_removeRepeatsC = shouldProduce [0,1,2,3,4,5,6,7,8,9, 10 :: Int] $
                             CC.yieldMany [0,0,0,1,1,1,2,2,3,4,5,6,6,6,6,7,7,8,9,10,10] .| CAlg.removeRepeatsC
 
 case_asyncMap :: IO ()
 case_asyncMap = do
     vals <- extractIO (CC.yieldMany [0..10] .| CAlg.asyncMapC 3 (+ (1:: Int)))
-    (vals @?= [1..11])
+    vals @?= [1..11]
 
 case_unorderedAsyncMapC :: IO ()
 case_unorderedAsyncMapC = do
     vals <- extractIO (CC.yieldMany [0..10] .| CAlg.unorderedAsyncMapC 3 (+ (1:: Int)))
-    (sort vals @?= [1..11])
+    sort vals @?= [1..11]
 
 case_asyncGzip :: IO ()
 case_asyncGzip = do
     C.runConduitRes (CC.yieldMany ["Hello", " ", "World"] .| CAlg.asyncGzipToFile testingFileNameGZ)
-    r <- B.concat <$> (extractIO (CAlg.asyncGzipFromFile testingFileNameGZ))
+    r <- B.concat <$> extractIO (CAlg.asyncGzipFromFile testingFileNameGZ)
     r @?= "Hello World"
     removeFile testingFileNameGZ
 
 case_asyncBzip2 :: IO ()
 case_asyncBzip2 = do
     C.runConduitRes (CC.yieldMany ["Hello", " ", "World"] .| CAlg.asyncBzip2ToFile testingFileNameBZ2)
-    r <- B.concat <$> (extractIO (CAlg.asyncBzip2FromFile testingFileNameBZ2))
+    r <- B.concat <$> extractIO (CAlg.asyncBzip2FromFile testingFileNameBZ2)
     r @?= "Hello World"
     removeFile testingFileNameBZ2
 
@@ -154,11 +172,11 @@ case_asyncXz = assertError $ do
 case_asyncXz = do
 #endif
     C.runConduitRes (CC.yieldMany ["Hello", " ", "World"] .| CAlg.asyncXzToFile testingFileNameXZ)
-    r <- B.concat <$> (extractIO (CAlg.asyncXzFromFile testingFileNameXZ))
+    r <- B.concat <$> extractIO (CAlg.asyncXzFromFile testingFileNameXZ)
     r @?= "Hello World"
     removeFile testingFileNameXZ
 
-
+case_async_gzip_to_from :: IO ()
 case_async_gzip_to_from = do
     let testdata = [0 :: Int .. 12]
     C.runConduitRes $
@@ -175,6 +193,7 @@ case_async_gzip_to_from = do
     removeFile testingFileNameGZ
     removeFile testingFileNameGZ2
 
+case_async_bzip2_to_from :: IO ()
 case_async_bzip2_to_from = do
     let testdata = [0 :: Int .. 12]
     C.runConduitRes $
@@ -191,6 +210,7 @@ case_async_bzip2_to_from = do
     removeFile testingFileNameBZ2
     removeFile testingFileNameBZ22
 
+case_async_xz_to_from :: IO ()
 #ifdef WINDOWS
 case_async_xz_to_from = assertError $ do
 #else
@@ -211,15 +231,18 @@ case_async_xz_to_from = do
     removeFile testingFileNameXZ
     removeFile testingFileNameXZ2
 
+case_asyncFilterLines :: IO ()
 case_asyncFilterLines = do
     vals <- extractIO (CC.yieldMany ["This is\nMy data\nBut"," sometimes","\nit is split,\n","in weird ways."] .| CAlg.asyncFilterLinesC 2 (B8.notElem ','))
-    (vals @?= ["This is", "My data", "But sometimes", "in weird ways."])
+    vals @?= ["This is", "My data", "But sometimes", "in weird ways."]
 
+case_asyncFilterLinesAllTrue :: IO ()
 case_asyncFilterLinesAllTrue = do
     vals <- extractIO (CC.yieldMany ["This is\nMy data\nBut"," sometimes","\nit is split,\n","in weird ways."] .| CAlg.asyncFilterLinesC 2 (const True))
-    (vals @?= ["This is", "My data", "But sometimes", "it is split,", "in weird ways."])
+    vals @?= ["This is", "My data", "But sometimes", "it is split,", "in weird ways."]
 
+case_storableVector :: IO ()
 case_storableVector = do
     let v = VS.fromList [0:: Int, 1, 2, 4, 6, 12]
     vals <- extractIO (CC.yieldMany [v,v,v] .| CAlg.writeStorableV .| CAlg.readStorableV 3)
-    (VS.concat vals @=? VS.concat [v,v,v])
+    VS.concat vals @=? VS.concat [v,v,v]


### PR DESCRIPTION
My previous patch was incomplete in terms of support on windows.

Bzip2 is now available but lzma isn't. Tests now check that an error is generated on windows.

Windows is now also tested using AppVeyor as seen in: https://ci.appveyor.com/project/Unode/conduit-algorithms (it will be necessary to allow this repository once merged).

This change is part of a set of changes to also revive and test windows support for NGLess which currently fails due to conduit-algorithms trying to compile lzma.