### PR TITLE
LZMA/XZ now compiles on Windows

### DIFF
--- a/Data/Conduit/Algorithms/Async.hs
+++ b/Data/Conduit/Algorithms/Async.hs
@@ -39,9 +39,7 @@ import qualified Data.Conduit.Async as CA
 import qualified Data.Conduit.TQueue as CA
 import qualified Data.Conduit.List as CL
 import qualified Data.Conduit.Zlib as CZ
-#ifndef WINDOWS
 import qualified Data.Conduit.Lzma as CX
-#endif
 import qualified Data.Streaming.Zlib as SZ
 import qualified Data.Conduit.BZlib as CZ
 import qualified Data.Conduit as C
@@ -296,11 +294,7 @@ asyncXzTo h = do
                 CA.sourceTBQueue q
                     .| untilNothing
                     .| CL.map (B.concat . reverse)
-#ifndef WINDOWS
                     .| CX.compress Nothing
-#else
-                    .| error "lzma/xz compression is not available on Windows"
-#endif
                     .| C.sinkHandle h
     bsConcatTo ((2 :: Int) ^ (15 :: Int))
         .| CA.drainTo 8 drain
@@ -326,11 +320,7 @@ asyncXzFrom h = do
         prod q = do
                     C.runConduit $
                         C.sourceHandle h
-#ifndef WINDOWS
                             .| CZ.multiple (CX.decompress oneGBmembuffer)
-#else
-                            .| error "lzma/xz decompression is not available on Windows"
-#endif
                             .| CL.map Just
                             .| CA.sinkTBQueue q
                     liftIO $ atomically (TQ.writeTBQueue q Nothing)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,9 @@
 
 build: off
 
+cache:
+  - C:\sr -> stack.yaml
+
 before_test:
 # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%

--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ dependencies:
   - containers
   - deepseq
   - exceptions
+  - lzma-conduit
   - monad-control
   - mtl
   - resourcet
@@ -45,11 +46,7 @@ dependencies:
 
 when:
   - condition: ! 'os(windows)'
-    then:
-     cpp-options: -DWINDOWS
-    else:
-     dependencies:
-     - lzma-conduit
+    cpp-options: -DWINDOWS
 
 library:
   exposed-modules:

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,8 @@ resolver: lts-11.0
 
 packages:
 - .
-extra-deps: []
+extra-deps:
+- lzma-clib-5.2.2
 
 flags: {}
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -166,11 +166,7 @@ case_asyncBzip2 = do
     removeFile testingFileNameBZ2
 
 case_asyncXz :: IO ()
-#ifdef WINDOWS
-case_asyncXz = assertError $ do
-#else
 case_asyncXz = do
-#endif
     C.runConduitRes (CC.yieldMany ["Hello", " ", "World"] .| CAlg.asyncXzToFile testingFileNameXZ)
     r <- B.concat <$> extractIO (CAlg.asyncXzFromFile testingFileNameXZ)
     r @?= "Hello World"
@@ -211,11 +207,7 @@ case_async_bzip2_to_from = do
     removeFile testingFileNameBZ22
 
 case_async_xz_to_from :: IO ()
-#ifdef WINDOWS
-case_async_xz_to_from = assertError $ do
-#else
 case_async_xz_to_from = do
-#endif
     let testdata = [0 :: Int .. 12]
     C.runConduitRes $
         CC.yieldMany testdata


### PR DESCRIPTION
Adding `lzma-clib-5.2.2` to `extra-deps` allows use of Lzma/Xz on Windows.